### PR TITLE
CVSB-14406 - updated api spec file to match the latest version of test-results API spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "cvs-tsk-edh-dispatcher",
   "version": "0.0.1",
-  "engines" : { "node" : ">8.10" },
+  "engines": {
+    "node": ">8.10"
+  },
   "description": "Receives DynamoDB Streams destined for EDH and parcels them out to their respective SQS queues",
   "main": "handler.js",
   "scripts": {

--- a/src/resources/API_Vehicle_Test_Results_CVS->EDH_v1.yaml
+++ b/src/resources/API_Vehicle_Test_Results_CVS->EDH_v1.yaml
@@ -156,6 +156,7 @@ components:
         reasonForCreation:
           type: string
           nullable: true
+          maxLength: 500
           description: 'Applicable only when updating/creating a test from VTM'
         createdAt:
           type: string
@@ -177,6 +178,9 @@ components:
         lastUpdatedById:
           type: string
           description: 'Applicable only when updating/creating a test from VTM'
+        shouldEmailCertificate:
+          type: string
+          description: 'Not sent from FE, calculated in BE. Applicable only when updating a test from VTM. Used to determine if a certificate should be emailed or not after an update.'
         testStationName:
           type: string
           maxLength: 999
@@ -399,6 +403,7 @@ components:
         reasonForCreation:
           type: string
           nullable: true
+          maxLength: 500
           description: 'Applicable only when updating/creating a test from VTM'
         createdAt:
           type: string
@@ -420,6 +425,9 @@ components:
         lastUpdatedById:
           type: string
           description: 'Applicable only when updating/creating a test from VTM'
+        shouldEmailCertificate:
+          type: string
+          description: 'Not sent from FE, calculated in BE. Applicable only when updating a test from VTM. Used to determine if a certificate should be emailed or not after an update.'
         testStationName:
           type: string
           maxLength: 999
@@ -672,6 +680,10 @@ components:
           format: date-time
           nullable: true
           description: Nullable only for Cancelled tests.
+        statusUpdatedFlag:
+          type: boolean
+          nullable: true
+          description: 'Sent from FE. Used to determine which test-type was updated/archived'
         numberOfSeatbeltsFitted:
           type: number
           nullable: true

--- a/tests/resources/demoTestResult.json
+++ b/tests/resources/demoTestResult.json
@@ -19,12 +19,14 @@
   "testStationPNumber": "09-4129632",
   "testStationType": "gvts",
   "testStatus": "submitted",
+  "shouldEmailCertificate": "true",
   "testTypes": [
     {
       "additionalCommentsForAbandon": null,
       "additionalNotesRecorded": "sds",
       "certificateNumber": "W01A00633",
       "createdAt": "2020-04-15T09:44:27.616Z",
+      "statusUpdatedFlag": false,
       "customDefects": [
 
       ],


### PR DESCRIPTION
Updated the test-results API spec to reflect the latest changes done as part of 14406 and 10280 (added shouldEmailCertificate and statusUpdatedFlag attributes)

https://jira.dvsacloud.uk/browse/CVSB-14406